### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
This adds a .gitignore file, using their C++ template. This should ignore any files you try to upload that match any of the patterns in the file. For example, it will ignore all of the `.obj`, `.dll`, `.exe`, and `.lib` files, the `.obj` ones I think being the biggest issue with so many of them being generated.

If you merge this pull request and then try to upload files with any of the extensions in the `.gitignore` file, those files will be ignored anyway.